### PR TITLE
Upgrade terraform modules

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -2,41 +2,45 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/hashicorp/aws" {
-  version     = "3.75.2"
-  constraints = ">= 2.23.0, ~> 3.0, >= 3.63.0, >= 3.72.0"
+  version     = "4.59.0"
+  constraints = ">= 2.23.0, >= 3.63.0, >= 3.72.0, ~> 4.0, >= 4.47.0"
   hashes = [
-    "h1:lcSLAmkNM1FvNhqAEbh2oTZRqF37HKRh1Di8LvssYBY=",
-    "zh:0e75fb14ec42d69bc46461dd54016bb2487d38da324222cec20863918b8954c4",
-    "zh:30831a1fe29f005d8b809250b43d09522288db45d474c9d238b26f40bdca2388",
-    "zh:36163d625ab2999c9cd31ef2475d978f9f033a8dfa0d585f1665f2d6492fac4b",
-    "zh:48ec39685541e4ddd8ddd196e2cfb72516b87f471d86ac3892bc11f83c573199",
-    "zh:707b9c8775efd6962b6226d914ab25f308013bba1f68953daa77adca99ff6807",
-    "zh:72bd9f4609a827afa366c6f119c7dec7d73a35d712dad1457c0497d87bf8d160",
-    "zh:930e3ae3d0cb152e17ee5a8aee5cb47f7613d6421bc7c22e7f50c19da484a100",
+    "h1:irUD0Fq6r6y9l03z1rza6Vv70iTt6OdvKS9wJF4QajE=",
+    "zh:0341a460210463a0bebd5c12ce13dc49bd8cae2399b215418c5efa607fed84e4",
+    "zh:0544e9bbdd31d3551e7273bed7326d26a28653fd9c26b5cd06ac8ed76f188798",
+    "zh:3d13acd0363f0a48d2725cae9d224481df38dddb90ef4a66eb82303f0aa45a99",
+    "zh:416f5b92d41dce1d7ee1a1acb06ba8b0f10679eecee2fcc134853adbb09d9757",
+    "zh:80c9c3b901151cd697caa58bfa196816d4622e4ce11aa789e36efc460695313b",
+    "zh:8fc3659ebdae1ac9de899f57e5a3a50274a2e96c46aa2cf74be51ffdac56300a",
     "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
-    "zh:a19bf49b80101a0f0272b994153eeff8f8c206ecc592707bfbce7563355b6882",
-    "zh:a34b5d2bbaf52285b0c9a8df6258f4789f4d927ff777e126bdc77e7887abbeaa",
-    "zh:caad6fd5e79eae33e6d74e38c3b15c28a5482f2a1a8ca46cc1ee70089de61adb",
-    "zh:f2eae988635030de9a088f8058fbcd91e2014a8312a48b16bfd09a9d69d9d6f7",
+    "zh:a235b44ad074446a6138b3fb454dd0d234aacf7a1efea89d1eafac7284689d19",
+    "zh:a36a7f1cd7f9f6c45127d916a65b5441cc0430393535a5a3de4b646405c50c41",
+    "zh:c161c38727902271efa19020b95b69ebe0282989d575f31dff603a1d551bafd2",
+    "zh:d1562223347c49cbe3ff6e7295e25816a35dfef862d28cd8a7870e7be6ec8093",
+    "zh:e7a1d08bfe91d3789755ee587fc816907c3bea203342c717144c7459111ce20c",
+    "zh:e89d5a668c391669ed323d493c5ea131fe8833d562a6fe31f525bdcbe959056e",
+    "zh:f268ccd3e1a32ba7fd59bbf0c8d85611201c0c87462a2a5cddd02babde7b5fe8",
+    "zh:fe8c2eae8c367d2cb7cade250a8d5f6c411ac4a8214c46df0a1fd90d9eaf7152",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/cloudinit" {
-  version     = "2.2.0"
+  version     = "2.3.2"
   constraints = ">= 2.0.0"
   hashes = [
-    "h1:siiI0wK6/jUDdA5P8ifTO0yc9YmXHml4hz5K9I9N+MA=",
-    "zh:76825122171f9ea2287fd27e23e80a7eb482f6491a4f41a096d77b666896ee96",
-    "zh:795a36dee548e30ca9c9d474af9ad6d29290e0a9816154ad38d55381cd0ab12d",
-    "zh:9200f02cb917fb99e44b40a68936fd60d338e4d30a718b7e2e48024a795a61b9",
-    "zh:a33cf255dc670c20678063aa84218e2c1b7a67d557f480d8ec0f68bc428ed472",
-    "zh:ba3c1b2cd0879286c1f531862c027ec04783ece81de67c9a3b97076f1ce7f58f",
-    "zh:bd575456394428a1a02191d2e46af0c00e41fd4f28cfe117d57b6aeb5154a0fb",
-    "zh:c68dd1db83d8437c36c92dc3fc11d71ced9def3483dd28c45f8640cfcd59de9a",
-    "zh:cbfe34a90852ed03cc074601527bb580a648127255c08589bc3ef4bf4f2e7e0c",
-    "zh:d6ffd7398c6d1f359b96f5b757e77b99b339fbb91df1b96ac974fe71bc87695c",
-    "zh:d9c15285f847d7a52df59e044184fb3ba1b7679fd0386291ed183782683d9517",
-    "zh:f7dd02f6d36844da23c9a27bb084503812c29c1aec4aba97237fec16860fdc8c",
+    "h1:Ar/DAbZQ9Nsj0BrqX6camrEE6U+Yq4E87DCNVqxqx8k=",
+    "zh:2487e498736ed90f53de8f66fe2b8c05665b9f8ff1506f751c5ee227c7f457d1",
+    "zh:3d8627d142942336cf65eea6eb6403692f47e9072ff3fa11c3f774a3b93130b3",
+    "zh:434b643054aeafb5df28d5529b72acc20c6f5ded24decad73b98657af2b53f4f",
+    "zh:436aa6c2b07d82aa6a9dd746a3e3a627f72787c27c80552ceda6dc52d01f4b6f",
+    "zh:458274c5aabe65ef4dbd61d43ce759287788e35a2da004e796373f88edcaa422",
+    "zh:54bc70fa6fb7da33292ae4d9ceef5398d637c7373e729ed4fce59bd7b8d67372",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:893ba267e18749c1a956b69be569f0d7bc043a49c3a0eb4d0d09a8e8b2ca3136",
+    "zh:95493b7517bce116f75cdd4c63b7c82a9d0d48ec2ef2f5eb836d262ef96d0aa7",
+    "zh:9ae21ab393be52e3e84e5cce0ef20e690d21f6c10ade7d9d9d22b39851bfeddc",
+    "zh:cc3b01ac2472e6d59358d54d5e4945032efbc8008739a6d4946ca1b621a16040",
+    "zh:f23bfe9758f06a1ec10ea3a81c9deedf3a7b42963568997d84a5153f35c5839a",
   ]
 }
 
@@ -79,22 +83,42 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/tls" {
-  version     = "3.4.0"
-  constraints = "~> 3.0"
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.9.1"
+  constraints = ">= 0.9.0"
   hashes = [
-    "h1:fSRc/OyRitbAST9vE+mEcmgJiDp+Jx8pGPbUUeYEQRc=",
-    "zh:2442a0df0cfb550b8eba9b2af39ac06f54b62447eb369ecc6b1c29f739b33bbb",
-    "zh:3ebb82cacb677a099de55f844f0d02886bc804b1a2b94441bc40fabcb64d2a38",
-    "zh:436125c2a7e66bc62a4a7c68bdca694f071d7aa894e8637dc83f4a68fe322546",
-    "zh:5f03db9f1d77e8274ff4750ae32d5c16c42b862b06bcb0683e4d733c8db922e4",
+    "h1:UHcDnIYFZ00uoou0TwPGMwOrE8gTkoRephIvdwDAK70=",
+    "zh:00a1476ecf18c735cc08e27bfa835c33f8ac8fa6fa746b01cd3bcbad8ca84f7f",
+    "zh:3007f8fc4a4f8614c43e8ef1d4b0c773a5de1dcac50e701d8abc9fdc8fcb6bf5",
+    "zh:5f79d0730fdec8cb148b277de3f00485eff3e9cf1ff47fb715b1c969e5bbd9d4",
     "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8190142ae8a539ab34193b7e75da0fa04035d1dcd8af8be94df1eafeeffb44b6",
-    "zh:8cdc7cd9221e27c189e5beaf78462fce4c2edb081f415a1eafc6da2949de31e2",
-    "zh:a5de0f7f5d63c59ebf61d3c1d94040f410665ff0aa04f66674efe24b39a11f94",
-    "zh:a9fce48db3c140cc3e06f8a3c7ef4d36735e457e7660442d6d5dcd2b0781adc3",
-    "zh:beb92de584c790c7c7f047e45ccd22b6ee3263c7b5a91ae4d6882ae6e7700570",
-    "zh:f373f8cc52846fb513f44f468d885f722ca4dc22af9ff1942368cafd16b796b3",
-    "zh:f69627fd6e5a920b17ff423cdbad2715078ca6d13146dc67668795582ab43748",
+    "zh:8c8094689a2bed4bb597d24a418bbbf846e15507f08be447d0a5acea67c2265a",
+    "zh:a6d9206e95d5681229429b406bc7a9ba4b2d9b67470bda7df88fa161508ace57",
+    "zh:aa299ec058f23ebe68976c7581017de50da6204883950de228ed9246f309e7f1",
+    "zh:b129f00f45fba1991db0aa954a6ba48d90f64a738629119bfb8e9a844b66e80b",
+    "zh:ef6cecf5f50cda971c1b215847938ced4cb4a30a18095509c068643b14030b00",
+    "zh:f1f46a4f6c65886d2dd27b66d92632232adc64f92145bf8403fe64d5ffa5caea",
+    "zh:f79d6155cda7d559c60d74883a24879a01c4d5f6fd7e8d1e3250f3cd215fb904",
+    "zh:fd59fa73074805c3575f08cd627eef7acda14ab6dac2c135a66e7a38d262201c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.0.4"
+  constraints = ">= 3.0.0"
+  hashes = [
+    "h1:Wd3RqmQW60k2QWPN4sK5CtjGuO1d+CRNXgC+D4rKtXc=",
+    "zh:23671ed83e1fcf79745534841e10291bbf34046b27d6e68a5d0aab77206f4a55",
+    "zh:45292421211ffd9e8e3eb3655677700e3c5047f71d8f7650d2ce30242335f848",
+    "zh:59fedb519f4433c0fdb1d58b27c210b27415fddd0cd73c5312530b4309c088be",
+    "zh:5a8eec2409a9ff7cd0758a9d818c74bcba92a240e6c5e54b99df68fff312bbd5",
+    "zh:5e6a4b39f3171f53292ab88058a59e64825f2b842760a4869e64dc1dc093d1fe",
+    "zh:810547d0bf9311d21c81cc306126d3547e7bd3f194fc295836acf164b9f8424e",
+    "zh:824a5f3617624243bed0259d7dd37d76017097dc3193dac669be342b90b2ab48",
+    "zh:9361ccc7048be5dcbc2fafe2d8216939765b3160bd52734f7a9fd917a39ecbd8",
+    "zh:aa02ea625aaf672e649296bce7580f62d724268189fe9ad7c1b36bb0fa12fa60",
+    "zh:c71b4cd40d6ec7815dfeefd57d88bc592c0c42f5e5858dcc88245d371b4b8b1e",
+    "zh:dabcd52f36b43d250a3d71ad7abfa07b5622c69068d989e60b79b2bb4f220316",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ It also installs some addons for a functional kubernetes cluster:
 - ExternalDNS addon
 
 To test the cluster, an app (podinfo) is deployed to make sure the cluster and the different addons (Ingress Controller, CertManager and ExternalDNS) are working as expected.
+
+Optionally, [kube-cert-acm](https://github.com/mstiri/kube-cert-acm) can be enabled and installed on the cluster.

--- a/cluster.tf
+++ b/cluster.tf
@@ -2,16 +2,22 @@
 
 ### EKS Cluster creation
 module "eks" {
-  source                               = "terraform-aws-modules/eks/aws"
-  version                              = "~> 19.0"
-  cluster_version                      = var.cluster_version
-  cluster_name                         = local.cluster_name
-  vpc_id                               = module.vpc.vpc_id
-  subnet_ids                           = module.vpc.private_subnets
-  cluster_endpoint_public_access       = true
-  cluster_endpoint_private_access      = true
-  cluster_endpoint_public_access_cidrs = var.kubeapi_allowed_cidrs
-  enable_irsa                          = true
+  source                                        = "terraform-aws-modules/eks/aws"
+  version                                       = "~> 19.0"
+  cluster_version                               = var.cluster_version
+  cluster_name                                  = local.cluster_name
+  vpc_id                                        = module.vpc.vpc_id
+  subnet_ids                                    = module.vpc.private_subnets
+  cluster_endpoint_public_access                = true
+  cluster_endpoint_private_access               = true
+  cluster_endpoint_public_access_cidrs          = var.kubeapi_allowed_cidrs
+  enable_irsa                                   = true
+  node_security_group_enable_recommended_rules  = true
+
+  create_kms_key            = true
+  cluster_encryption_config = {
+    resources = ["secrets"]
+  }
 
   eks_managed_node_group_defaults = {
     ami_type       = "AL2_x86_64"
@@ -37,31 +43,7 @@ module "eks" {
 
   # Extend node-to-node security group rules
   node_security_group_additional_rules = {
-    ingress_self_all = {
-      description = "Node to node all ports/protocols"
-      protocol    = "-1"
-      from_port   = 0
-      to_port     = 0
-      type        = "ingress"
-      self        = true
-    }
-    ingress_cluster_all = {
-      description                   = "Cluster to node all ports/protocols"
-      protocol                      = "-1"
-      from_port                     = 0
-      to_port                       = 0
-      type                          = "ingress"
-      source_cluster_security_group = true
-    }
-    egress_all = {
-      description      = "Node all egress"
-      protocol         = "-1"
-      from_port        = 0
-      to_port          = 0
-      type             = "egress"
-      cidr_blocks      = ["0.0.0.0/0"]
-      ipv6_cidr_blocks = ["::/0"]
-    }
+
   }
 
   eks_managed_node_groups = {

--- a/cluster.tf
+++ b/cluster.tf
@@ -3,7 +3,7 @@
 ### EKS Cluster creation
 module "eks" {
   source                               = "terraform-aws-modules/eks/aws"
-  version                              = "~> 18.0"
+  version                              = "~> 19.0"
   cluster_version                      = var.cluster_version
   cluster_name                         = local.cluster_name
   vpc_id                               = module.vpc.vpc_id

--- a/main.tf
+++ b/main.tf
@@ -14,25 +14,21 @@ locals {
 }
 
 ### Kubernetes provider configuration
-data "aws_eks_cluster" "eks" {
-  name = module.eks.cluster_name
-}
-
 data "aws_eks_cluster_auth" "eks" {
   name = module.eks.cluster_name
 }
 
 provider "kubernetes" {
-  host                   = data.aws_eks_cluster.eks.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
   token                  = data.aws_eks_cluster_auth.eks.token
 }
 
-### Helm provider configuration
+### Helm provider configuration
 provider "helm" {
   kubernetes {
-    host                   = data.aws_eks_cluster.eks.endpoint
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.eks.certificate_authority[0].data)
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
     token                  = data.aws_eks_cluster_auth.eks.token
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -13,13 +13,13 @@ locals {
   account_id = data.aws_caller_identity.current.account_id
 }
 
-### Kubernetes provider configuration
+### Kubernetes provider configuration
 data "aws_eks_cluster" "eks" {
-  name = module.eks.cluster_id
+  name = module.eks.cluster_name
 }
 
 data "aws_eks_cluster_auth" "eks" {
-  name = module.eks.cluster_id
+  name = module.eks.cluster_name
 }
 
 provider "kubernetes" {

--- a/network.tf
+++ b/network.tf
@@ -3,7 +3,7 @@
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.14.2"
+  version = "3.19.0"
 
   name                 = "vpc_${var.environment}"
   cidr                 = var.vpc_cidr

--- a/platform/cert-manager.tf
+++ b/platform/cert-manager.tf
@@ -4,7 +4,7 @@ module "iam_assumable_role_for_cert_manager" {
   version                       = "4.11.0"
   create_role                   = true
   number_of_role_policy_arns    = 1
-  role_name                     = "cert-manager-role-${var.eks.cluster_id}"
+  role_name                     = "cert-manager-role-${var.eks.cluster_name}"
   provider_url                  = replace(var.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.cert_manager.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.cert-manager.namespace}:${var.cert-manager.service_account}"]
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "cert_manager" {
   }
 }
 resource "aws_iam_policy" "cert_manager" {
-  name   = "cert-manager-policy-${var.eks.cluster_id}"
+  name   = "cert-manager-policy-${var.eks.cluster_name}"
   policy = data.aws_iam_policy_document.cert_manager.json
 }
 

--- a/platform/cert-manager.tf
+++ b/platform/cert-manager.tf
@@ -1,7 +1,7 @@
 
 module "iam_assumable_role_for_cert_manager" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "4.11.0"
+  version                       = "5.14.3"
   create_role                   = true
   number_of_role_policy_arns    = 1
   role_name                     = "cert-manager-role-${var.eks.cluster_name}"

--- a/platform/external-dns.tf
+++ b/platform/external-dns.tf
@@ -1,7 +1,7 @@
 
 module "iam_assumable_role_for_external_dns" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "4.11.0"
+  version                       = "5.14.3"
   create_role                   = true
   number_of_role_policy_arns    = 1
   role_name                     = "external-dns-role-${var.eks.cluster_name}"

--- a/platform/external-dns.tf
+++ b/platform/external-dns.tf
@@ -4,13 +4,13 @@ module "iam_assumable_role_for_external_dns" {
   version                       = "4.11.0"
   create_role                   = true
   number_of_role_policy_arns    = 1
-  role_name                     = "external-dns-role-${var.eks.cluster_id}"
+  role_name                     = "external-dns-role-${var.eks.cluster_name}"
   provider_url                  = replace(var.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.external_dns.arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.external-dns.namespace}:${var.external-dns.service_account}"]
 }
 
-# ExternalDNS policy 
+# ExternalDNS policy
 data "aws_iam_policy_document" "external_dns" {
   statement {
     actions   = ["sts:AssumeRole"]
@@ -36,7 +36,7 @@ data "aws_iam_policy_document" "external_dns" {
 }
 
 resource "aws_iam_policy" "external_dns" {
-  name   = "external-dns-policy-${var.eks.cluster_id}"
+  name   = "external-dns-policy-${var.eks.cluster_name}"
   policy = data.aws_iam_policy_document.external_dns.json
 }
 

--- a/platform/kube-cert-acm.tf
+++ b/platform/kube-cert-acm.tf
@@ -2,7 +2,7 @@
 module "iam_assumable_role_for_kube_cert_acm" {
   count                         = var.kube-cert-acm.enabled ? 1 : 0
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "4.11.0"
+  version                       = "5.14.3"
   create_role                   = true
   number_of_role_policy_arns    = 1
   role_name                     = "kube-cert-acm-role-${var.eks.cluster_name}"

--- a/platform/kube-cert-acm.tf
+++ b/platform/kube-cert-acm.tf
@@ -5,7 +5,7 @@ module "iam_assumable_role_for_kube_cert_acm" {
   version                       = "4.11.0"
   create_role                   = true
   number_of_role_policy_arns    = 1
-  role_name                     = "kube-cert-acm-role-${var.eks.cluster_id}"
+  role_name                     = "kube-cert-acm-role-${var.eks.cluster_name}"
   provider_url                  = replace(var.eks.cluster_oidc_issuer_url, "https://", "")
   role_policy_arns              = [aws_iam_policy.kube_cert_acm[count.index].arn]
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.kube-cert-acm.namespace}:${var.kube-cert-acm.service_account}"]
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "kube_cert_acm" {
 }
 resource "aws_iam_policy" "kube_cert_acm" {
   count  = var.kube-cert-acm.enabled ? 1 : 0
-  name   = "kube-cert-acm-policy-${var.eks.cluster_id}"
+  name   = "kube-cert-acm-policy-${var.eks.cluster_name}"
   policy = data.aws_iam_policy_document.kube_cert_acm[count.index].json
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
Upgrade terraform modules to the most recent versions:
- terraform-aws-eks **v18.x** to **v19.x**
- iam-assumable-role-with-oidc from **4.11.0** to **5.14.3**
- terraform-aws-vpc from **3.14.2** to **3.19.0**